### PR TITLE
Update values.schema.json for mc-router

### DIFF
--- a/charts/mc-router/values.schema.json
+++ b/charts/mc-router/values.schema.json
@@ -142,7 +142,7 @@
             "backend": {
               "type": "string",
               "title": "Backend to use for metrics exposure/publishing",
-              "enum": ["discard", "expvar", "influxdb"]
+              "enum": ["discard", "expvar", "influxdb", "prometheus"]
             }
           },
           "if": {


### PR DESCRIPTION
Prometheus metrics are available from the application itself: https://github.com/itzg/mc-router/blob/master/cmd/mc-router/metrics.go#L31C8-L31C18

If you use this value in the helmchart, helm will fail during validation as it's not allowed in the schema.

```Helm upgrade failed for release default/minecraft-router with chart mc-router@1.2.5+556b89e29b95: values don't meet the specifications of the schema(s) in the following chart(s): mc-router: - minecraftRouter.metrics.backend: minecraftRouter.metrics.backend must be one of the following: "discard", "expvar", "influxdb"```